### PR TITLE
Update p12-to-jks.sh

### DIFF
--- a/p12-to-jks.sh
+++ b/p12-to-jks.sh
@@ -69,7 +69,7 @@ echo 3/4: Converting PEM to P12
 
 echo
 echo "--- ENTER YOUR NEW PASSWORD --- "
-openssl pkcs12 -export -out $OUTFILE.p12 \
+openssl pkcs12 -export -out $OUTFILE \
   -inkey privateKey.pem \
   -in publicCert.pem \
   -passin pass:$NEW_PW \
@@ -82,7 +82,7 @@ echo 4/4: Converting new P12 to JKS keystore
 echo
 echo "--- ENTER YOUR NEW PASSWORD --- "
 keytool -importkeystore \
-    -srckeystore $OUTFILE.p12 \
+    -srckeystore $OUTFILE \
     -srcstoretype pkcs12 \
     -destkeystore $OUTFILE.jks \
     -deststoretype jks \


### PR DESCRIPTION
Running p12-to-jks with the file extension for the out file according to the example creates a file with a double extension.

./p12-to-jks in.p12 out.p12 myalias outputs a file named "out.p12.p12" instead of "out.p12" which is expected. Removing the hardcoded extension from line 72 and 85 solves this so the user can get a file with whatever name/extension.