### PR TITLE
Update p12-to-jks.sh

### DIFF
--- a/p12-to-jks.sh
+++ b/p12-to-jks.sh
@@ -8,7 +8,7 @@ DEST_ALIAS=$3
 function usage() {
   #echo "USAGE:   ./p12-to-jks <INPUT_CERT_P12_FILE> <OUTPUT_CERT_P12_FILE> <INPUT_ALIAS> <OUTPUT_ALIAS>"
   echo "USAGE:   ./p12-to-jks <INPUT_CERT_P12_FILE> <OUTPUT_CERT_P12_FILE> <OUTPUT_ALIAS>"
-  echo "EXAMPLE: ./p12-to-jks in.p12 out.p12 myalias"
+  echo "EXAMPLE: ./p12-to-jks in.p12 out myalias"
 }
 
 if [ -z "$INFILE" ]


### PR DESCRIPTION
Removed the .p12 extension from the out file in the usage example. If specifying .p12 the exported .p12 with have a double extension "out.p12.p12" and the exported JKS will be "out.p12.jks"